### PR TITLE
fix: update websocket import logic

### DIFF
--- a/packages/actor-core/src/common/websocket.ts
+++ b/packages/actor-core/src/common/websocket.ts
@@ -1,16 +1,16 @@
 export async function importWebSocket(): Promise<typeof WebSocket> {
 	let _WebSocket: typeof WebSocket;
-	
-	if (typeof WebSocket !== "undefined") {
-		// Browser environment
-		_WebSocket = WebSocket;
-	} else {
-		try {
-			// Node.js environment
-			const ws = await import("ws");
-			console.log('toimiiko tää selaimes', ws)
-			_WebSocket = ws.WebSocket as unknown as typeof WebSocket;
-		} catch {
+
+	// Node.js environment
+	try {
+		const ws = await import("ws");
+		if (!ws.WebSocket) throw "Unsupported";
+		_WebSocket = ws.WebSocket as unknown as typeof WebSocket;
+	} catch {
+		if (typeof WebSocket !== "undefined") {
+			// Browser environment
+			_WebSocket = WebSocket;
+		} else {
 			// WS not available
 			_WebSocket = class MockWebSocket {
 				constructor() {
@@ -18,7 +18,7 @@ export async function importWebSocket(): Promise<typeof WebSocket> {
 						'WebSocket support requires installing the "ws" package',
 					);
 				}
-			} as unknown as typeof WebSocket; 
+			} as unknown as typeof WebSocket;
 		}
 	}
 

--- a/packages/actor-core/src/common/websocket.ts
+++ b/packages/actor-core/src/common/websocket.ts
@@ -1,15 +1,16 @@
 export async function importWebSocket(): Promise<typeof WebSocket> {
 	let _WebSocket: typeof WebSocket;
-
-	// Node.js environment
-	try {
-		const ws = await import("ws");
-		_WebSocket = ws.WebSocket as unknown as typeof WebSocket;
-	} catch {
-		if (typeof WebSocket !== "undefined") {
-			// Browser environment
-			_WebSocket = WebSocket;
-		} else {
+	
+	if (typeof WebSocket !== "undefined") {
+		// Browser environment
+		_WebSocket = WebSocket;
+	} else {
+		try {
+			// Node.js environment
+			const ws = await import("ws");
+			console.log('toimiiko tää selaimes', ws)
+			_WebSocket = ws.WebSocket as unknown as typeof WebSocket;
+		} catch {
 			// WS not available
 			_WebSocket = class MockWebSocket {
 				constructor() {
@@ -17,7 +18,7 @@ export async function importWebSocket(): Promise<typeof WebSocket> {
 						'WebSocket support requires installing the "ws" package',
 					);
 				}
-			} as unknown as typeof WebSocket;
+			} as unknown as typeof WebSocket; 
 		}
 	}
 


### PR DESCRIPTION
As discussed in this discussion https://github.com/rivet-gg/actor-core/discussions/621, you get following error when initializing Client on browser environment
```
Uncaught (in promise) TypeError: WebSocket2 is not a constructor
```
This most likely happens because on the [websocket.ts](https://github.com/rivet-gg/actor-core/blob/main/packages/actor-core/src/common/websocket.ts) file we first try to import ws dynamically, if that is successful we never reach the catch block. For some reason importing ws on the browser environment does not throw even though the `ws` package is not designed to be used on browser. 

In this PR I flipped the logic other way around, if typeof Websocket  is not defined, browser Websocket implementation is used. If Websocket does not exist we try to import `ws`. 

Let me know if this makes sense or not?