### PR TITLE
fix(cli): add `tsx` package to CLI examples

### DIFF
--- a/examples/chat-room/package.json
+++ b/examples/chat-room/package.json
@@ -12,7 +12,8 @@
     "@types/prompts": "^2",
     "actor-core": "workspace:*",
     "prompts": "^2.4.2",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "tsx": "^3.12.7"
   },
   "example": {
     "platforms": [

--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -10,7 +10,8 @@
   "devDependencies": {
     "@types/node": "^22.13.9",
     "actor-core": "workspace:*",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "tsx": "^3.12.7"
   },
   "example": {
     "platforms": [


### PR DESCRIPTION
Ran `npx create-actor@latest` and then gave the `chat-room` a go before realising the `test` command wouldn't run because `tsx` isn't installed

```
➜ npm run test

> chat-room@0.0.0 test
> tsx tests/client.ts

sh: tsx: command not found
```

And for other commands like `start` and `dev` for `nodejs`

https://github.com/rivet-gg/actor-core/blob/a9a5cfa5b91aff73889bbbee965d52221f89c2c7/packages/actor-core-cli/src/utils/platforms.ts#L246-L248