### PR TITLE
docs: update hono docs Cloudflare example

### DIFF
--- a/docs/integrations/hono.mdx
+++ b/docs/integrations/hono.mdx
@@ -32,7 +32,8 @@ Each platform has specific requirements for integrating Hono with ActorCore.
 ### Cloudflare Workers
 
 ```typescript
-import { setup, createRouter } from "@actor-core/cloudflare-workers";
+import { createRouter } from "@actor-core/cloudflare-workers";
+import { setup } from "actor-core";
 import { Hono } from "hono";
 import counter from "./counter";
 


### PR DESCRIPTION
To fix `Module '"@actor-core/cloudflare-workers"' has no exported member 'setup'.ts(2305)`

![image](https://github.com/user-attachments/assets/bf35683f-0e60-43ae-a0ee-940f979db082)