### PR TITLE
feat: add ability to access driver context

### DIFF
--- a/packages/actor-core/src/actor/config.ts
+++ b/packages/actor-core/src/actor/config.ts
@@ -114,7 +114,7 @@ type CreateVars<S, CP, CS, V> =
 			/**
 			 * @experimental
 			 */
-			createVars: (c: ActorContext<S, CP, CS, undefined>) => V | Promise<V>;
+			createVars: (c: ActorContext<S, CP, CS, undefined>, driverCtx: unknown) => V | Promise<V>;
 	  }
 	| Record<never, never>;
 

--- a/packages/actor-core/src/actor/driver.ts
+++ b/packages/actor-core/src/actor/driver.ts
@@ -11,6 +11,7 @@ export type KvValue = unknown;
 
 export interface ActorDriver {
 	//load(): Promise<LoadOutput>;
+	get context(): unknown;
 
 	// HACK: Clean these up
 	kvGet(actorId: string, key: KvKey): Promise<KvValue | undefined>;

--- a/packages/actor-core/src/actor/instance.ts
+++ b/packages/actor-core/src/actor/instance.ts
@@ -172,6 +172,7 @@ export class ActorInstance<S, CP, CS, V> {
 			if ("createVars" in this.#config) {
 				const dataOrPromise = this.#config.createVars(
 					this.actorContext as unknown as ActorContext<S, CP, CS, undefined>,
+					this.#actorDriver.context,
 				);
 				if (dataOrPromise instanceof Promise) {
 					vars = await deadline(dataOrPromise, CREATE_VARS_TIMEOUT);

--- a/packages/drivers/memory/src/actor.ts
+++ b/packages/drivers/memory/src/actor.ts
@@ -1,6 +1,10 @@
 import type { ActorDriver, KvKey, KvValue, AnyActorInstance } from "actor-core/driver-helpers";
 import type { MemoryGlobalState } from "./global_state";
 
+export interface ActorDriverContext {
+	state: MemoryGlobalState;
+}
+
 export class MemoryActorDriver implements ActorDriver {
 	#state: MemoryGlobalState;
 
@@ -8,7 +12,7 @@ export class MemoryActorDriver implements ActorDriver {
 		this.#state = state;
 	}
 
-	get context(): unknown {
+	get context(): ActorDriverContext {
 		return { state: this.#state };
 	}
 
@@ -61,7 +65,7 @@ export class MemoryActorDriver implements ActorDriver {
 
 	async setAlarm(actor: AnyActorInstance, timestamp: number): Promise<void> {
 		setTimeout(() => {
-			 actor.onAlarm();
+			actor.onAlarm();
 		}, timestamp - Date.now());
 	}
 

--- a/packages/drivers/memory/src/actor.ts
+++ b/packages/drivers/memory/src/actor.ts
@@ -9,7 +9,7 @@ export class MemoryActorDriver implements ActorDriver {
 	}
 
 	get context(): unknown {
-		return this.#state;
+		return { state: this.#state };
 	}
 
 	async kvGet(actorId: string, key: KvKey): Promise<KvValue | undefined> {

--- a/packages/drivers/memory/src/actor.ts
+++ b/packages/drivers/memory/src/actor.ts
@@ -8,6 +8,10 @@ export class MemoryActorDriver implements ActorDriver {
 		this.#state = state;
 	}
 
+	get context(): unknown {
+		return this.#state;
+	}
+
 	async kvGet(actorId: string, key: KvKey): Promise<KvValue | undefined> {
 		const serializedKey = this.#serializeKey(key);
 		const value = this.#state.getKv(actorId, serializedKey);

--- a/packages/drivers/redis/src/actor.ts
+++ b/packages/drivers/redis/src/actor.ts
@@ -10,6 +10,10 @@ export class RedisActorDriver implements ActorDriver {
         this.#redis = redis;
     }
 
+    get context(): unknown {
+        return this.#redis
+    }
+
     async kvGet(actorId: string, key: KvKey): Promise<KvValue | undefined> {
         const value = await this.#redis.get(this.#serializeKey(actorId, key));
         if (value !== null) return JSON.parse(value);

--- a/packages/drivers/redis/src/actor.ts
+++ b/packages/drivers/redis/src/actor.ts
@@ -11,7 +11,7 @@ export class RedisActorDriver implements ActorDriver {
     }
 
     get context(): unknown {
-        return this.#redis
+        return { redis: this.#redis };
     }
 
     async kvGet(actorId: string, key: KvKey): Promise<KvValue | undefined> {

--- a/packages/drivers/redis/src/actor.ts
+++ b/packages/drivers/redis/src/actor.ts
@@ -3,6 +3,10 @@ import type Redis from "ioredis";
 import { KEYS } from "./keys";
 import { AnyActorInstance } from "actor-core/driver-helpers";
 
+export interface ActorDriverContext {
+    redis: Redis;
+}
+
 export class RedisActorDriver implements ActorDriver {
     #redis: Redis;
 
@@ -10,7 +14,7 @@ export class RedisActorDriver implements ActorDriver {
         this.#redis = redis;
     }
 
-    get context(): unknown {
+    get context(): ActorDriverContext {
         return { redis: this.#redis };
     }
 

--- a/packages/platforms/cloudflare-workers/src/actor_driver.ts
+++ b/packages/platforms/cloudflare-workers/src/actor_driver.ts
@@ -7,6 +7,10 @@ export class CloudflareWorkersActorDriver implements ActorDriver {
 		this.#doCtx = ctx;
 	}
 
+	get context(): unknown {
+		return this.#doCtx;
+	}
+
 	async kvGet(_actorId: string, key: KvKey): Promise<KvValue | undefined> {
 		return await this.#doCtx.storage.get(this.#serializeKey(key));
 	}

--- a/packages/platforms/cloudflare-workers/src/actor_driver.ts
+++ b/packages/platforms/cloudflare-workers/src/actor_driver.ts
@@ -1,5 +1,10 @@
 import { ActorDriver, KvKey, KvValue, AnyActorInstance } from "actor-core/driver-helpers";
 
+export interface ActorDriverContext {
+	ctx: DurableObjectState;
+	env: unknown;
+}
+
 export class CloudflareWorkersActorDriver implements ActorDriver {
 	#doCtx: DurableObjectState;
 	#env: unknown;
@@ -9,7 +14,7 @@ export class CloudflareWorkersActorDriver implements ActorDriver {
 		this.#env = env;
 	}
 
-	get context(): unknown {
+	get context(): ActorDriverContext {
 		return { ctx: this.#doCtx, env: this.#env };
 	}
 

--- a/packages/platforms/cloudflare-workers/src/actor_driver.ts
+++ b/packages/platforms/cloudflare-workers/src/actor_driver.ts
@@ -2,13 +2,15 @@ import { ActorDriver, KvKey, KvValue, AnyActorInstance } from "actor-core/driver
 
 export class CloudflareWorkersActorDriver implements ActorDriver {
 	#doCtx: DurableObjectState;
+	#env: unknown;
 
-	constructor(ctx: DurableObjectState) {
+	constructor(ctx: DurableObjectState, env: unknown) {
 		this.#doCtx = ctx;
+		this.#env = env;
 	}
 
 	get context(): unknown {
-		return this.#doCtx;
+		return { ctx: this.#doCtx, env: this.#env };
 	}
 
 	async kvGet(_actorId: string, key: KvKey): Promise<KvValue | undefined> {

--- a/packages/platforms/cloudflare-workers/src/actor_handler_do.ts
+++ b/packages/platforms/cloudflare-workers/src/actor_handler_do.ts
@@ -94,7 +94,7 @@ export function createActorDurableObject(
 			// Create topology
 			if (!config.drivers) config.drivers = {};
 			if (!config.drivers.actor)
-				config.drivers.actor = new CloudflareWorkersActorDriver(this.ctx);
+				config.drivers.actor = new CloudflareWorkersActorDriver(this.ctx, this.env);
 			if (!config.getUpgradeWebSocket)
 				config.getUpgradeWebSocket = () => upgradeWebSocket;
 			const actorTopology = new PartitionTopologyActor(app.config, config);

--- a/packages/platforms/rivet/src/actor_driver.ts
+++ b/packages/platforms/rivet/src/actor_driver.ts
@@ -1,6 +1,10 @@
 import type { ActorContext } from "@rivet-gg/actor-core";
 import type { ActorDriver, KvKey, KvValue, AnyActorInstance } from "actor-core/driver-helpers";
 
+export interface ActorDriverContext {
+	ctx: ActorContext;
+}
+
 export class RivetActorDriver implements ActorDriver {
 	#ctx: ActorContext;
 
@@ -8,7 +12,7 @@ export class RivetActorDriver implements ActorDriver {
 		this.#ctx = ctx;
 	}
 
-	get context(): unknown {
+	get context(): ActorDriverContext {
 		return { ctx: this.#ctx };
 	}
 

--- a/packages/platforms/rivet/src/actor_driver.ts
+++ b/packages/platforms/rivet/src/actor_driver.ts
@@ -8,6 +8,10 @@ export class RivetActorDriver implements ActorDriver {
 		this.#ctx = ctx;
 	}
 
+	get context(): unknown {
+		return this.#ctx;
+	}
+
 	async kvGet(_actorId: string, key: KvKey): Promise<KvValue | undefined> {
 		return await this.#ctx.kv.get(key);
 	}

--- a/packages/platforms/rivet/src/actor_driver.ts
+++ b/packages/platforms/rivet/src/actor_driver.ts
@@ -9,7 +9,7 @@ export class RivetActorDriver implements ActorDriver {
 	}
 
 	get context(): unknown {
-		return this.#ctx;
+		return { ctx: this.#ctx };
 	}
 
 	async kvGet(_actorId: string, key: KvKey): Promise<KvValue | undefined> {


### PR DESCRIPTION
As discussed in [discord](https://discord.com/channels/822914074136018994/1070989358225690665/1353803015265718366), this implements the minimal viable API to get context from the driver. 

The only change is an update to the callsite of `createVars` and a change to the driver interface. 

```ts
actor({
  createVars(c, driverCtx) {
    // Do something w/ the driverCtx ...
  }
})
```

```ts
interface ActorDriver {
  get context(): unknown
  // ...everything else
}
```