### PR TITLE
(fix) redis key when creating actor

### DIFF
--- a/packages/drivers/redis/src/manager.ts
+++ b/packages/drivers/redis/src/manager.ts
@@ -118,7 +118,7 @@ export class RedisManagerDriver implements ManagerDriver {
 			[KEYS.ACTOR.initialized(actorId)]: "1",
 			[KEYS.ACTOR.name(actorId)]: name,
 			[KEYS.ACTOR.tags(actorId)]: JSON.stringify(tags),
-			[`actor_tags:${JSON.stringify(tags)}:id`]: actorId,
+			[`actor_tags:${name}:${JSON.stringify(tags)}:id`]: actorId,
 		});
 
 		return {


### PR DESCRIPTION
When using redis driver - actor gets recreated on every connection: [See on discord](https://discord.com/channels/822914074136018994/1357372876109512794/1357372876109512794)