### PR TITLE
Add `get-port` as dev dep

### DIFF
--- a/packages/actor-core/package.json
+++ b/packages/actor-core/package.json
@@ -175,6 +175,7 @@
     "@types/node": "^22.13.1",
     "@types/ws": "^8",
     "eventsource": "^3.0.5",
+    "get-port": "^7.1.0"
     "tsup": "^8.4.0",
     "typescript": "^5.7.3",
     "vitest": "^3.0.9",

--- a/packages/actor-core/package.json
+++ b/packages/actor-core/package.json
@@ -175,7 +175,7 @@
     "@types/node": "^22.13.1",
     "@types/ws": "^8",
     "eventsource": "^3.0.5",
-    "get-port": "^7.1.0"
+    "get-port": "^7.1.0",
     "tsup": "^8.4.0",
     "typescript": "^5.7.3",
     "vitest": "^3.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,6 +3057,7 @@ __metadata:
     "@types/ws": "npm:^8"
     cbor-x: "npm:^1.6.0"
     eventsource: "npm:^3.0.5"
+    get-port: "npm:^7.1.0"
     hono: "npm:^4.7.0"
     invariant: "npm:^2.2.4"
     on-change: "npm:^5.0.1"


### PR DESCRIPTION
In #790 `get-port` was added to [`packages/actor-core/src/test/mod.ts`](packages/actor-core/src/test/mod.ts)

Get an error when you run the example

```sh
npx create-actor@0.7.9
npm run test
```

```
➜ npm run test

> counter@0.0.0 test
> vitest run


 RUN  v3.1.1 /Users/username/git/actor-core-counter


⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/counter.test.ts [ tests/counter.test.ts ]
Error: Cannot find package 'get-port' imported from /Users/username/git/actor-core-counter/node_modules/actor-core/dist/test/mod.js
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  no tests
   Start at  14:59:12
   Duration  209ms (transform 24ms, setup 0ms, collect 0ms, tests 0ms, environment 0ms, prepare 35ms)
```